### PR TITLE
add optional controller support

### DIFF
--- a/lib/router.module.js
+++ b/lib/router.module.js
@@ -10,7 +10,7 @@ var RouterModule_1;
 const common_1 = require("@nestjs/common");
 const validate_path_util_1 = require("./utils/validate-path.util");
 const flat_routes_util_1 = require("./utils/flat-routes.util");
-const MODULE_PATH = '__module_path__';
+const constants_1 = require("@nestjs/common/constants");
 /**
  * A utility Module to Organize your Routes,
  * it could be imported in the Root Module of you application.
@@ -29,7 +29,8 @@ let RouterModule = RouterModule_1 = class RouterModule {
     static buildPathMap(routes) {
         const flattenRoutes = flat_routes_util_1.flatRoutes(routes);
         flattenRoutes.forEach(route => {
-            Reflect.defineMetadata(MODULE_PATH, validate_path_util_1.validatePath(route.path), route.module);
+            route.controller ? Reflect.defineMetadata(constants_1.PATH_METADATA, validate_path_util_1.validatePath(route.path), route.controller)
+                : Reflect.defineMetadata(constants_1.MODULE_PATH, validate_path_util_1.validatePath(route.path), route.module);
         });
     }
 };

--- a/lib/routes.interface.d.ts
+++ b/lib/routes.interface.d.ts
@@ -3,12 +3,14 @@
  * - `path` - a string describe the Module path which will be applied
  * to all it's controllers and childs
  * - `module` - the parent Module.
+ * - `controller` - the parent Controller.
  * - `children` - an array of child Modules.
  * - `childrens` @deprecated - @see children
  */
 export interface Route {
     path: string;
     module?: any;
+    controller?: any;
     childrens?: any[];
     children?: any[];
 }

--- a/lib/utils/flat-routes.util.js
+++ b/lib/utils/flat-routes.util.js
@@ -5,7 +5,7 @@ const validate_path_util_1 = require("./validate-path.util");
 const result = [];
 function flatRoutes(routes) {
     routes.forEach(element => {
-        if (element.module && element.path) {
+        if ((element.module || element.controller) && element.path) {
             result.push(element);
         }
         // this block will be removed soon

--- a/src/router.module.ts
+++ b/src/router.module.ts
@@ -2,7 +2,7 @@ import { Module, DynamicModule } from '@nestjs/common';
 import { validatePath } from './utils/validate-path.util';
 import { flatRoutes } from './utils/flat-routes.util';
 import { Routes } from './routes.interface';
-const MODULE_PATH = '__module_path__';
+import { PATH_METADATA, MODULE_PATH } from '@nestjs/common/constants';
 /**
  * A utility Module to Organize your Routes,
  * it could be imported in the Root Module of you application.
@@ -22,7 +22,8 @@ export class RouterModule {
   private static buildPathMap(routes: Routes) {
     const flattenRoutes = flatRoutes(routes);
     flattenRoutes.forEach(route => {
-      Reflect.defineMetadata(MODULE_PATH, validatePath(route.path), route.module);
+      route.controller ? Reflect.defineMetadata(PATH_METADATA, validatePath(route.path), route.controller)
+        : Reflect.defineMetadata(MODULE_PATH, validatePath(route.path), route.module);
     });
   }
 }

--- a/src/routes.interface.ts
+++ b/src/routes.interface.ts
@@ -3,12 +3,14 @@
  * - `path` - a string describe the Module path which will be applied
  * to all it's controllers and childs
  * - `module` - the parent Module.
+ * - `controller` - the parent Controller.
  * - `children` - an array of child Modules.
  * - `childrens` @deprecated - @see children
  */
 export interface Route {
   path: string;
   module?: any;
+  controller?: any;
   childrens?: any[];
   children?: any[];
 }

--- a/src/utils/flat-routes.util.ts
+++ b/src/utils/flat-routes.util.ts
@@ -5,7 +5,7 @@ import { validatePath } from './validate-path.util';
 const result = [];
 export function flatRoutes(routes: Routes) {
   routes.forEach(element => {
-    if (element.module && element.path) {
+    if ((element.module || element.controller) && element.path) {
       result.push(element);
     }
     // this block will be removed soon


### PR DESCRIPTION
Sometime we need directly define controller's path because not all path finder in nestjs equal
to  module path + controller path.

For example, in Middleware
`consumer.apply(someMiddleware).forRoutes(SomeController);`
it only find PATH_METADATA, not MODULE_PATH.

The change in PR also make us lose ability to define own route in Decorator @Controller，but I think it is not important. Decorator route in controller class is not necessary with nested routes.